### PR TITLE
Protect against recursive executeProposal attack

### DIFF
--- a/DBVN.sol
+++ b/DBVN.sol
@@ -186,9 +186,9 @@ contract DBVN is owned {
         /* execute result */
         if (p.currentResult > majorityMargin) {     
             /* If difference between support and opposition is larger than margin */
-            p.recipient.call.value(p.amount)(transactionBytecode);
             p.executed = true;
             p.proposalPassed = true;
+            p.recipient.call.value(p.amount)(transactionBytecode);
         } else {
             p.executed = true;
             p.proposalPassed = false;


### PR DESCRIPTION
The DBVN has a minor recursive call vulnerability. 

Smart-contracts on ethereum have a default function, also called a fallback function, and this is what causes recursive call bugs. When a contract calls another contract, the other contract could include code in the default function to call the original function on the calling contract, and this second recursive call would be processed before the first one was finished. 

Since the DBVN changes the state of the proposal to `p.executed = true` only after it has called the recipient, `p.recipient.call.value(p.amount)(transactionBytecode)`, the recipient could perform a recursive call attack.

For example, a contract could do a recursive call attack with this fallback function, and get 101x the payout.

```
function() {

    for(uint i = 0; i<100; i++) {
        DBVN.executeProposal(proposalNumber, transactionBytecode);
    }
}
```

This is a minor vulnerability since the DBVN is able to audit the code of `recipient` (in the case recipient is a contract)

I've written a short report about the bug, and included links to learn more about re-entry attacks,
https://medium.com/@crypto_nation/report-recursive-call-vulnerability-in-dbvn-sol-471d99e30659#.r4lczodvf
