### PR TITLE
check return value of low level call

### DIFF
--- a/DBVN.sol
+++ b/DBVN.sol
@@ -188,7 +188,7 @@ contract DBVN is owned {
             /* If difference between support and opposition is larger than margin */
             p.executed = true;
             p.proposalPassed = true;
-            p.recipient.call.value(p.amount)(transactionBytecode);
+            if(!p.recipient.call.value(p.amount)(transactionBytecode)) throw;
         } else {
             p.executed = true;
             p.proposalPassed = false;


### PR DESCRIPTION
CALL will put different values on the stack depending on whether an EVM-exception occurred in the called contract. 

Add a check for wether .call was a success and returns `true`.

http://www.blunderingcode.com/writing-secure-solidity/
https://blog.ethereum.org/2016/06/10/smart-contract-security/